### PR TITLE
	modified:   dbpedia_dumps_parser.py

### DIFF
--- a/extern/ld/parsers/dbpedia_infobox_dump_parser.py
+++ b/extern/ld/parsers/dbpedia_infobox_dump_parser.py
@@ -20,23 +20,28 @@ from base_parsers import OfflineParser
 
 class DbpediaInfoboxParser(OfflineParser):
 
-    def __init__(self, basedir='dbpedia_dumps',
+    def __init__(self, basedir='dbpedia_dumps', new_parse=False,
                  needed_fn='dbpedia_ontology_languages'):
 
         self.basedir = basedir
         self.def_result_fn = "saved_infobox_results.pickle"
+        if new_parse is True:
+            self.load_data_for_parsing()
+
+    def load_data_for_parsing(self):
+
+        self.needed_titles = set([l.strip('\n').decode('unicode_escape')
+                                   for l in open(
+                                       '{0}/{1}'
+                                       .format(self.basedir, self.needed_fn))])
         self.fh = open('{0}/raw_infobox_properties_en.nt'
-                       .format(self.basedir))
+                        .format(self.basedir))
         self.needed_properties = set(['spokenIn', 'altname', 'iso',
                                       'lc', 'ld', 'name', 'nativename',
                                       'script', 'states', 'nation',
                                      'iso1', 'iso2', 'iso2b', 'iso2t'])
         self.multiple_properties = set(['spokenIn', 'altname', 'states'])
         self.splitters = re.compile('[,;]')
-        self.needed_titles = set([l.strip('\n').decode('unicode_escape')
-                                  for l in open(
-                                      '{0}/{1}'
-                                      .format(basedir, needed_fn))])
 
     def generate_language_blocks(self):
 
@@ -167,9 +172,9 @@ class DbpediaInfoboxParser(OfflineParser):
 
 def main():
 
-    parser = DbpediaInfoboxParser()
+    parser = DbpediaInfoboxParser(new_parse=False)
     for d in parser.parse():
-        if d[u'sil'] == 'deu':
+        if d[u'sil'] == 'ger':
             print repr(d)
 
 

--- a/extern/ld/parsers/dbpedia_shortabstract_parser.py
+++ b/extern/ld/parsers/dbpedia_shortabstract_parser.py
@@ -19,18 +19,22 @@ from base_parsers import OfflineParser
 
 class DbpediaShortAbstractsParser(OfflineParser):
 
-    def __init__(self, basedir='dbpedia_dumps',
+    def __init__(self, basedir='dbpedia_dumps', new_parse=False,
                  needed_fn='dbpedia_ontology_languages'):
 
         self.basedir = basedir
+        self.def_result_fn = "saved_shortabstract_results.pickle"
+        if new_parse is True:
+            self.load_data_for_parsing()
+
+    def load_data_for_parsing(self):
         self.fh = open('{0}/short_abstracts_en.nt'
                        .format(self.basedir))
         self.patterns = self.compile_patterns()
-        self.def_result_fn = "saved_shortabstract_results.pickle"
         self.needed_titles = set([l.strip('\n').decode('unicode_escape')
                                   for l in open(
                                       '{0}/{1}'
-                                  .format(basedir, needed_fn))])
+                                      .format(self.basedir, self.needed_fn))])
 
     def compile_patterns(self):
 
@@ -188,7 +192,7 @@ class DbpediaShortAbstractsParser(OfflineParser):
 
 def main():
 
-    parser = DbpediaShortAbstractsParser()
+    parser = DbpediaShortAbstractsParser(new_parse=False)
     for d in parser.parse():
         print d
 


### PR DESCRIPTION
```
modified:   dbpedia_infobox_dump_parser.py
modified:   dbpedia_shortabstract_parser.py
```

dbpedia_shortabstract_parser.py and dbpedia_infobox_dump_parser.py have  parameter in **init** denoting wther it is necessary to have dump data
(if parsing is already done only the result files are needed)
- sil list is to be given to parse() method of DbpediaDumpsParser
- description for dbpedia_dumps_parser.py
