### PR TITLE
Serialize/deserialize support in BaseParser

### DIFF
--- a/extern/ld/parsers/base_parsers.py
+++ b/extern/ld/parsers/base_parsers.py
@@ -28,7 +28,7 @@ class BaseParser(object):
             d = list(self.parse_all())
             with open(fn, 'wb') as f:
                 f.write(cPickle.dumps(d))
-            return list(self.parse_all())
+            return d
 
     def parse_all(self):
         yield None


### PR DESCRIPTION
- dump_to_file: dumps the list of parse_all method's yield values to file in cPickle format
- load_from_file: reads cPickle file
- parse_all: yield language data, one dictionary/language. The subclasses must override this method in order to use the serialization
- _parse_or_load_ : if the pickle file exists, load it instead of parsing. If it doesn't exist, parse everything and save it in pickle

Discussion is welcome
